### PR TITLE
Add help from inside the mtd-console

### DIFF
--- a/Commands.js
+++ b/Commands.js
@@ -7,7 +7,9 @@ var Package = require('./package.json');
 var _ = require('underscore');
 var Db = require('./Db');
 var fs = require('fs');
-var wrap = require('wordwrap')
+
+var wrap = require('wordwrap');
+var path = require('path');
 
 var log = console.log;
 
@@ -37,9 +39,21 @@ var _auto_name = function (url, callback) {
 };
 
 var _show_help = function () {
-	var text = fs.readFileSync(__dirname + '/usage').toString().split('\n');
-	for (i in text){
-		console.log(wrap(1,80)(text[i]));
+	var text = fs.readFileSync(path.join(__dirname, 'usage')).toString().split('\n');
+	var line;
+	for(i in text) {
+		line = text[i];
+		if(line){
+			var s;
+			if (line.indexOf('::') > 0) {
+				var a = wrap(1,20)(line.split('::')[0]);					
+				var b = wrap(20,80)(line.split('::')[1]);
+				s = a + b.substr(a.length)
+			} else { 
+				s = wrap(1,80)(line); 
+			};
+		console.log(s);
+		}
 	}
 };
 

--- a/Commands.js
+++ b/Commands.js
@@ -6,7 +6,8 @@ var f = require('./Formaters');
 var Package = require('./package.json');
 var _ = require('underscore');
 var Db = require('./Db');
-var fs = require('fs')
+var fs = require('fs');
+var wrap = require('wordwrap')
 
 var log = console.log;
 
@@ -37,8 +38,9 @@ var _auto_name = function (url, callback) {
 
 var _show_help = function () {
 	var text = fs.readFileSync(__dirname + '/usage').toString().split('\n');
-	console.log(text);
-	console.log('To know more visit [https://github.com/tusharmath/mtd-console]');
+	for (i in text){
+		console.log(wrap(1,80)(text[i]));
+	}
 };
 
 var _set_wd = function (args) {

--- a/Commands.js
+++ b/Commands.js
@@ -6,6 +6,7 @@ var f = require('./Formaters');
 var Package = require('./package.json');
 var _ = require('underscore');
 var Db = require('./Db');
+var fs = require('fs')
 
 var log = console.log;
 
@@ -35,6 +36,8 @@ var _auto_name = function (url, callback) {
 };
 
 var _show_help = function () {
+	var text = fs.readFileSync(__dirname + '/usage').toString().split('\n');
+	console.log(text);
 	console.log('To know more visit [https://github.com/tusharmath/mtd-console]');
 };
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ $ npm install -g mt-console
 
 ##Usage
 
-1. You can get started by using the ```--help``` option. This lists out all the possible operations in mtd.
+You can get started by using the ```--help``` option. This lists out all the possible operations in mtd.
 
     ```bash
     $ mtd --help
     ```
 
-2. To start a new download you will have to provide a ```--url``` and a download ```--file``` path.
+To start a new download you will have to provide a ```--url``` and a download ```--file``` path.
 
     ```bash
     $ mtd --url="http://path/to/file.zip" --file="/Downloads/file.zip"
@@ -28,25 +28,25 @@ $ npm install -g mt-console
 
     **NOTE:** Make sure to use the double quotes to avoid possible problems.
 
-3. To resume an old download, you just need to provide the path to the file with .mtd extension that is temporarily created at the time of download.
+To resume an old download, you just need to provide the path to the file with .mtd extension that is temporarily created at the time of download.
 
     ```bash
     $ mtd --file="/Downloads/file.zip.mtd"
     ```
 
-4. You can also pass custom options such as -
+You can also pass custom options such as:
 
-    a. ```--count``` : To set a custom number of download threads. It defaults to what is set in the [mt-downloader](https://github.com/tusharmath/Multi-threaded-downloader) library.
+     ```--count``` : To set a custom number of download threads. It defaults to what is set in the [mt-downloader](https://github.com/tusharmath/Multi-threaded-downloader) library.
 
-    b. ```--range``` : You can specify a custom download range. This feature is particularly useful when you want to download a part of a video file. Say you just want to download the later half of the file, you can then set the range as **50-100**. Its an optional parameter and defaults to **0-100**.
+     ```--range``` : You can specify a custom download range. This feature is particularly useful when you want to download a part of a video file. Say you just want to download the later half of the file, you can then set the range as **50-100**. Its an optional parameter and defaults to **0-100**.
 
-    c. ```--port``` : You can specify a custom HTTP port. It defaults to **80**.
+     ```--port``` : You can specify a custom HTTP port. It defaults to **80**.
 
-    d. ```--method``` : You can specify the download method such as **PUT** and **POST** by default it is set to **GET**.
+     ```--method``` : You can specify the download method such as **PUT** and **POST** by default it is set to **GET**.
 
-    e. ```--wd``` : Shows the current working directory. You can update this using ```--set-wd``` option.
+     ```--wd``` : Shows the current working directory. You can update this using ```--set-wd``` option.
 
-    f. ```--set-wd``` : You can set you current working directory using this command. This is particularly helpful if you want to avoid typing the complete download path with the ```--file``` parameter. Instead you can set a common path for downloads and just specify the name of the file. The app will automatically combine the two and create the complete file path.
+     ```--set-wd``` : You can set you current working directory using this command. This is particularly helpful if you want to avoid typing the complete download path with the ```--file``` parameter. Instead you can set a common path for downloads and just specify the name of the file. The app will automatically combine the two and create the complete file path.
 
     ```bash
     $ mtd --set-wd="/Users/user/Downloads/"
@@ -62,13 +62,13 @@ $ npm install -g mt-console
 
     Both the files *file_one.zip* and *file_two.zip* will be downloaded at the same location ```/Users/users/Downloads/``` because that is the default download path.
 
-    g. ```--clear-wd``` : Clears the saved working directory.
+     ```--clear-wd``` : Clears the saved working directory.
 
-    h. ```--timeout``` : Sometimes the connections are established but are not transferring any data. Using this setting you can set the maximum amount of time in **seconds** that it should wait before quitting.
+     ```--timeout``` : Sometimes the connections are established but are not transferring any data. Using this setting you can set the maximum amount of time in **seconds** that it should wait before quitting.
 
-    i. ```--auto-name``` : Generates the file name on its own by parsing the last element of the url. You will not be required to set the ```--file``` parameter while starting a new download. It will also automatically prepend the generated file name with the working directory specified by the ```--set-wd``` option.
+     ```--auto-name``` : Generates the file name on its own by parsing the last element of the url. You will not be required to set the ```--file``` parameter while starting a new download. It will also automatically prepend the generated file name with the working directory specified by the ```--set-wd``` option.
 
-    j. ```--headers``` : You can specify headers by seperating them using semicolons as follows
+     ```--headers``` : You can specify headers by seperating them using semicolons as follows
 
     ```bash
     $ mtd --url="http://path/to/file_one.zip" --file="file_one.zip" --headers="user-agent:crawl-bot;cookie:abc%3D100%3Bpqr%3D200"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A platform independent console application for [mt-downloader](https://github.com/tusharmath/Multi-threaded-downloader). This app is only an abstraction of what the original library can do. To get a complete list of features you should see [mt-downloader](https://github.com/tusharmath/Multi-threaded-downloader).
 
+This fork makes the help option work as advertised
+
 ##Installation
 
 Install this globally using the conventional npm installation command.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ npm install -g mt-console
 
     ```
 
-    Both the files *file_one.zip* and *file_two.zip* will be downloaded at the same location ```/Users/users/Downloads/``` because that is the default download path.
+    Both *file_one.zip* and *file_two.zip* will be downloaded at the same location ```/Users/user/Downloads/``` because that is the default download path.
 
      ```--clear-wd``` : Clears the saved working directory.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ npm install -g mt-console
     $ mtd --url="http://path/to/file.zip" --file="/Downloads/file.zip"
     ```
 
-    **NOTE:** Make sure you use the double quotes because some times if you have spaces in your paths it creates problems.
+    **NOTE:** Make sure to use the double quotes to avoid possible problems.
 
 3. To resume an old download, you just need to provide the path to the file with .mtd extension that is temporarily created at the time of download.
 
@@ -49,18 +49,18 @@ $ npm install -g mt-console
     f. ```--set-wd``` : You can set you current working directory using this command. This is particularly helpful if you want to avoid typing the complete download path with the ```--file``` parameter. Instead you can set a common path for downloads and just specify the name of the file. The app will automatically combine the two and create the complete file path.
 
     ```bash
-    $ mtd --set-wd="/Users/tusharmathur/Downloads/"
-    $ Working directory updated to /Users/tusharmathur/Downloads/
+    $ mtd --set-wd="/Users/user/Downloads/"
+    $ Working directory updated to /Users/user/Downloads/
 
     $ mtd --wd
-    Working directory: /Users/tusharmathur/Downloads/
+    Working directory: /Users/user/Downloads/
 
     $ mtd --url="http://path/to/file_one.zip" --file="file_one.zip"
     $ mtd --url="http://path/to/file_two.zip" --file="file_two.zip"
 
     ```
 
-    Both the files *file_one.zip* and *file_two.zip* will be downloaded at the same location ```/Users/tusharmathur/Downloads/``` because that is the default download path.
+    Both the files *file_one.zip* and *file_two.zip* will be downloaded at the same location ```/Users/users/Downloads/``` because that is the default download path.
 
     g. ```--clear-wd``` : Clears the saved working directory.
 
@@ -75,5 +75,3 @@ $ npm install -g mt-console
     ```
 
     **NOTE:** make sure you encode the header values parameters while sending else they might get escaped while parsing.
-
-If you want to know more about this app you can visit [tusharm.com](http://tusharm.com/articles/mt-downloader). Hope this helps you in downloading your data more efficiently!

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ $ npm install -g mt-console
 
 ##Usage
 
-You can get started by using the ```--help``` option. This lists out all the possible operations in mtd.
+- You can get started by using the ```--help``` option. This lists out all the possible operations in mtd.  
 
     ```bash
-    $ mtd --help
+     $ mtd --help
     ```
 
-To start a new download you will have to provide a ```--url``` and a download ```--file``` path.
+- To start a new download you will have to provide a ```--url``` and a download ```--file``` path.
 
     ```bash
     $ mtd --url="http://path/to/file.zip" --file="/Downloads/file.zip"
@@ -28,13 +28,13 @@ To start a new download you will have to provide a ```--url``` and a download ``
 
     **NOTE:** Make sure to use the double quotes to avoid possible problems.
 
-To resume an old download, you just need to provide the path to the file with .mtd extension that is temporarily created at the time of download.
+- To resume an old download, you just need to provide the path to the file with .mtd extension that is temporarily created at the time of download.
 
     ```bash
     $ mtd --file="/Downloads/file.zip.mtd"
     ```
 
-You can also pass custom options such as:
+- You can also pass custom options such as:
 
      ```--count``` : To set a custom number of download threads. It defaults to what is set in the [mt-downloader](https://github.com/tusharmath/Multi-threaded-downloader) library.
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "underscore": "1.5.x",
     "minimist": "0.0.x",
     "mt-downloader": "0.2.x",
-    "moment": "2.0.x"
+    "moment": "2.0.x",
+    "wordwrap": "1.0.x"
   },
   "devDependencies": {
     "grunt-release": "0.3.x"

--- a/usage
+++ b/usage
@@ -3,8 +3,8 @@ Usage: mtd --url=URL --file=FILE [options]
 
 Mandatory arguments:
 
---url=URL           url to download
---file=FILE         path to local file
+--url=URL::url to download
+--file=FILE::path to local file
 
 Example: 
     mtd --url="http://path/to/file.zip" --file="/Downloads/file.zip"
@@ -18,18 +18,18 @@ Example: mtd --file="/Downloads/file.zip.mtd"
 Options:
 
 
---help              print this screen
+--help::print this screen
 
---count=COUNT       set number of download threads to COUNT. It defaults to what is set in the mt-downloader library.
+--count=COUNT::Set number of download threads to COUNT. It defaults to what is set in the mt-downloader library.
 
---range=X-Y         Specify a custom download range in percent. Set the range as 50-100 to download only the second half of a file. Defaults to 0-100.
+--range=X-Y::Specify a custom download range in percent. Set the range as 50-100 to download only the second half of a file. Defaults to 0-100.
 
---port=PORT         HTTP port to use. It defaults to 80.
+--port=PORT::HTTP port to use. It defaults to 80.
 
---method=           METHOD HTTP method, e.g. PUT or POST; defaults to GET.
+--method=METHOD::HTTP method, e.g. PUT or POST; defaults to GET.
 
---set-wd=DIR        Set the working directory where file(s) will be downloaded. The  complete file path will be DIR/FILE
---wd                Show the current working directory. Use --set-wd to update its value.
+--set-wd=DIR::Set the working directory where file(s) will be downloaded. The complete file path will be DIR/FILE
+--wd::Show the current working directory. Use --set-wd to update its value.
 
 Example:
 
@@ -45,13 +45,13 @@ mtd --url="http://path/to/file_two.zip" --file="file_two.zip"
 Both file_one.zip and file_two.zip will be downloaded at  
 /Users/tusharmathur/Downloads/ 
 
---clear-wd          Clears the saved working directory.
+--clear-wd::Clears the saved working directory.
 
---timeout=N         Set timeout to SECONDS; this is the time that the program should wait before quitting in case no data is transfered.
+--timeout=N::Set timeout to N seconds. This is the time that the program should wait before quitting in case no data is transfered.
 
---auto-name         Automatically generate a file name from the last element of the url. The --set-wd option will still be honored.
+--auto-name::Automatically generate a file name from the last element of the url. The --set-wd option will still be honored.
 
---headers=HEADERS   Pass custom HEADERS as key:value pairs separated by semicolons, e.g:
+--headers=HEADERS::Pass custom HEADERS as key:value pairs separated by semicolons, e.g:
 
 mtd --url="http://path/to/file_one.zip" --file="file_one.zip" --headers="user-agent:crawl-bot;cookie:abc%3D100%3Bpqr%3D200"
 

--- a/usage
+++ b/usage
@@ -1,6 +1,5 @@
 Usage: mtd --url=URL --file=FILE [options]
 
-mtd --help: print this screen
 
 Mandatory arguments:
 
@@ -17,6 +16,9 @@ Example: mtd --file="/Downloads/file.zip.mtd"
 
 
 Options:
+
+
+--help: print this screen
 
 --count=COUNT   set number of download threads to COUNT. It defaults to what is set in the mt-downloader library.
 

--- a/usage
+++ b/usage
@@ -3,6 +3,7 @@ Usage: mtd --url=URL --file=FILE [options]
 mtd --help: print this screen
 
 Mandatory arguments:
+
 --url=URL   url to download
 --file=FILE path to local file
 
@@ -12,7 +13,6 @@ Example:
 NOTE: Make sure to use double quotes since spaces in your paths can create problems.
 
 To resume an old download, just provide the path to the file with an .mtd extension that was temporarily created at the time of download.
-
 Example: mtd --file="/Downloads/file.zip.mtd"
 
 
@@ -20,15 +20,14 @@ Options:
 
 --count=COUNT   set number of download threads to COUNT. It defaults to what is set in the mt-downloader library.
 
---range=X-Y     Specify a custom download range in percent. Set the range as 50-100 to download only the second half of a file. Defaults to 0-100.
+--range=X-Y Specify a custom download range in percent. Set the range as 50-100 to download only the second half of a file. Defaults to 0-100.
 
---port=PORT     HTTP port to use. It defaults to 80.
+--port=PORT HTTP port to use. It defaults to 80.
 
 --method=METHOD HTTP method, e.g. PUT or POST; defaults to GET.
 
 --set-wd=DIR    Set the working directory where file(s) will be downloaded. The  complete file path will be DIR/FILE
---wd            Show the current working directory. 
-                Use --set-wd to update its value.
+--wd    Show the current working directory. Use --set-wd to update its value.
 Example:
 
 mtd --set-wd="/Users/tusharmathur/Downloads/"
@@ -43,11 +42,11 @@ mtd --url="http://path/to/file_two.zip" --file="file_two.zip"
 Both file_one.zip and file_two.zip will be downloaded at  
 /Users/tusharmathur/Downloads/ 
 
---clear-wd : Clears the saved working directory.
+--clear-wd  Clears the saved working directory.
 
---timeout=SECONDS   Set timeout to SECONDS; this is the time that the program should wait before quitting in case no data is transfered.
+--timeout=N Set timeout to SECONDS; this is the time that the program should wait before quitting in case no data is transfered.
 
---auto-name : Automatically generate a file name from the last element of the url. The --set-wd option will still be honored.
+--auto-name Automatically generate a file name from the last element of the url. The --set-wd option will still be honored.
 
 --headers=HEADERS   Pass custom HEADERS separated by semicolons, e.g:
 

--- a/usage
+++ b/usage
@@ -56,3 +56,6 @@ Both file_one.zip and file_two.zip will be downloaded at
 mtd --url="http://path/to/file_one.zip" --file="file_one.zip" --headers="user-agent:crawl-bot;cookie:abc%3D100%3Bpqr%3D200"
 
 header values parameters should be encoded or they might get escaped when parsed.
+
+
+Visit https://github.com/tusharmath/mtd-console for more information

--- a/usage
+++ b/usage
@@ -1,0 +1,51 @@
+    Usage: mtd --url=URL --file=FILE [options]
+
+    mtd --help: print this screen
+
+    To start a new download you will have to provide a --url and a download --file path.
+
+    mtd --url="http://path/to/file.zip" --file="/Downloads/file.zip"
+
+    NOTE: Make sure you use double quotes since spaces in your paths can create problems.
+
+    To resume an old download, just provide the path to the file with .mtd extension that is temporarily created at the time of download.
+
+    mtd --file="/Downloads/file.zip.mtd"
+
+    
+    You can also pass custom options such as:
+
+    --count : To set a custom number of download threads. It defaults to what is set in the mt-downloader library.
+
+    --range : specify a custom download range. This is particularly useful when you want to download a part of a video file. Say you just want to download the second half of the file, you can then set the range as 50-100. This optional parameter defaults to 0-100.
+
+    --port : You can specify a custom HTTP port. It defaults to 80.
+
+    --method : You can specify the download method such as PUT and POST, the default is set to GET.
+
+    --wd : Shows the current working directory. You can update this using --set-wd option.
+
+    --set-wd : You can set you current working directory using this command. This is particularly helpful if you want to avoid typing the complete download path with the --file parameter. Instead you can set a common path for downloads and just specify the name of the file. The app will automatically combine the two and create the complete file path.
+
+    mtd --set-wd="/Users/tusharmathur/Downloads/"
+    Working directory updated to /Users/tusharmathur/Downloads/
+
+    mtd --wd
+    Working directory: /Users/tusharmathur/Downloads/
+
+    mtd --url="http://path/to/file_one.zip" --file="file_one.zip"
+    mtd --url="http://path/to/file_two.zip" --file="file_two.zip"
+    
+    Both file_one.zip and file_two.zip will be downloaded at the same location /Users/tusharmathur/Downloads/ because that is the default download path.
+
+    --clear-wd : Clears the saved working directory.
+
+    --timeout : Sometimes the connections are established but are not transferring any data. Using this setting you can set the maximum amount of time in seconds that it should wait before quitting.
+
+    --auto-name : Generates the file name on its own by parsing the last element of the url. You will not be required to set the --file parameter while starting a new download. It will also automatically prepend the generated file name with the working directory specified by the --set-wd option.
+
+    --headers : You can specify headers by seperating them using semicolons as follows:
+
+    mtd --url="http://path/to/file_one.zip" --file="file_one.zip" --headers="user-agent:crawl-bot;cookie:abc%3D100%3Bpqr%3D200"
+    
+    NOTE: make sure to encode the header values parameters while sending else they might get escaped while parsing.

--- a/usage
+++ b/usage
@@ -3,8 +3,8 @@ Usage: mtd --url=URL --file=FILE [options]
 
 Mandatory arguments:
 
---url=URL       url to download
---file=FILE     path to local file
+--url=URL           url to download
+--file=FILE         path to local file
 
 Example: 
     mtd --url="http://path/to/file.zip" --file="/Downloads/file.zip"
@@ -18,18 +18,19 @@ Example: mtd --file="/Downloads/file.zip.mtd"
 Options:
 
 
---help          print this screen
+--help              print this screen
 
---count=COUNT   set number of download threads to COUNT. It defaults to what is set in the mt-downloader library.
+--count=COUNT       set number of download threads to COUNT. It defaults to what is set in the mt-downloader library.
 
---range=X-Y     Specify a custom download range in percent. Set the range as 50-100 to download only the second half of a file. Defaults to 0-100.
+--range=X-Y         Specify a custom download range in percent. Set the range as 50-100 to download only the second half of a file. Defaults to 0-100.
 
---port=PORT     HTTP port to use. It defaults to 80.
+--port=PORT         HTTP port to use. It defaults to 80.
 
---method=       METHOD HTTP method, e.g. PUT or POST; defaults to GET.
+--method=           METHOD HTTP method, e.g. PUT or POST; defaults to GET.
 
---set-wd=DIR    Set the working directory where file(s) will be downloaded. The  complete file path will be DIR/FILE
---wd            Show the current working directory. Use --set-wd to update its value.
+--set-wd=DIR        Set the working directory where file(s) will be downloaded. The  complete file path will be DIR/FILE
+--wd                Show the current working directory. Use --set-wd to update its value.
+
 Example:
 
 mtd --set-wd="/Users/tusharmathur/Downloads/"
@@ -50,7 +51,7 @@ Both file_one.zip and file_two.zip will be downloaded at
 
 --auto-name         Automatically generate a file name from the last element of the url. The --set-wd option will still be honored.
 
---headers=HEADERS   Pass custom HEADERS separated by semicolons, e.g:
+--headers=HEADERS   Pass custom HEADERS as key:value pairs separated by semicolons, e.g:
 
 mtd --url="http://path/to/file_one.zip" --file="file_one.zip" --headers="user-agent:crawl-bot;cookie:abc%3D100%3Bpqr%3D200"
 

--- a/usage
+++ b/usage
@@ -3,8 +3,8 @@ Usage: mtd --url=URL --file=FILE [options]
 
 Mandatory arguments:
 
---url=URL   url to download
---file=FILE path to local file
+--url=URL       url to download
+--file=FILE     path to local file
 
 Example: 
     mtd --url="http://path/to/file.zip" --file="/Downloads/file.zip"
@@ -18,18 +18,18 @@ Example: mtd --file="/Downloads/file.zip.mtd"
 Options:
 
 
---help: print this screen
+--help          print this screen
 
 --count=COUNT   set number of download threads to COUNT. It defaults to what is set in the mt-downloader library.
 
---range=X-Y Specify a custom download range in percent. Set the range as 50-100 to download only the second half of a file. Defaults to 0-100.
+--range=X-Y     Specify a custom download range in percent. Set the range as 50-100 to download only the second half of a file. Defaults to 0-100.
 
---port=PORT HTTP port to use. It defaults to 80.
+--port=PORT     HTTP port to use. It defaults to 80.
 
---method=METHOD HTTP method, e.g. PUT or POST; defaults to GET.
+--method=       METHOD HTTP method, e.g. PUT or POST; defaults to GET.
 
 --set-wd=DIR    Set the working directory where file(s) will be downloaded. The  complete file path will be DIR/FILE
---wd    Show the current working directory. Use --set-wd to update its value.
+--wd            Show the current working directory. Use --set-wd to update its value.
 Example:
 
 mtd --set-wd="/Users/tusharmathur/Downloads/"
@@ -44,11 +44,11 @@ mtd --url="http://path/to/file_two.zip" --file="file_two.zip"
 Both file_one.zip and file_two.zip will be downloaded at  
 /Users/tusharmathur/Downloads/ 
 
---clear-wd  Clears the saved working directory.
+--clear-wd          Clears the saved working directory.
 
---timeout=N Set timeout to SECONDS; this is the time that the program should wait before quitting in case no data is transfered.
+--timeout=N         Set timeout to SECONDS; this is the time that the program should wait before quitting in case no data is transfered.
 
---auto-name Automatically generate a file name from the last element of the url. The --set-wd option will still be honored.
+--auto-name         Automatically generate a file name from the last element of the url. The --set-wd option will still be honored.
 
 --headers=HEADERS   Pass custom HEADERS separated by semicolons, e.g:
 

--- a/usage
+++ b/usage
@@ -1,51 +1,56 @@
-    Usage: mtd --url=URL --file=FILE [options]
+Usage: mtd --url=URL --file=FILE [options]
 
-    mtd --help: print this screen
+mtd --help: print this screen
 
-    To start a new download you will have to provide a --url and a download --file path.
+Mandatory arguments:
+--url=URL   url to download
+--file=FILE path to local file
 
+Example: 
     mtd --url="http://path/to/file.zip" --file="/Downloads/file.zip"
 
-    NOTE: Make sure you use double quotes since spaces in your paths can create problems.
+NOTE: Make sure to use double quotes since spaces in your paths can create problems.
 
-    To resume an old download, just provide the path to the file with .mtd extension that is temporarily created at the time of download.
+To resume an old download, just provide the path to the file with an .mtd extension that was temporarily created at the time of download.
 
-    mtd --file="/Downloads/file.zip.mtd"
+Example: mtd --file="/Downloads/file.zip.mtd"
 
-    
-    You can also pass custom options such as:
 
-    --count : To set a custom number of download threads. It defaults to what is set in the mt-downloader library.
+Options:
 
-    --range : specify a custom download range. This is particularly useful when you want to download a part of a video file. Say you just want to download the second half of the file, you can then set the range as 50-100. This optional parameter defaults to 0-100.
+--count=COUNT   set number of download threads to COUNT. It defaults to what is set in the mt-downloader library.
 
-    --port : You can specify a custom HTTP port. It defaults to 80.
+--range=X-Y     Specify a custom download range in percent. Set the range as 50-100 to download only the second half of a file. Defaults to 0-100.
 
-    --method : You can specify the download method such as PUT and POST, the default is set to GET.
+--port=PORT     HTTP port to use. It defaults to 80.
 
-    --wd : Shows the current working directory. You can update this using --set-wd option.
+--method=METHOD HTTP method, e.g. PUT or POST; defaults to GET.
 
-    --set-wd : You can set you current working directory using this command. This is particularly helpful if you want to avoid typing the complete download path with the --file parameter. Instead you can set a common path for downloads and just specify the name of the file. The app will automatically combine the two and create the complete file path.
+--set-wd=DIR    Set the working directory where file(s) will be downloaded. The  complete file path will be DIR/FILE
+--wd            Show the current working directory. 
+                Use --set-wd to update its value.
+Example:
 
-    mtd --set-wd="/Users/tusharmathur/Downloads/"
-    Working directory updated to /Users/tusharmathur/Downloads/
+mtd --set-wd="/Users/tusharmathur/Downloads/"
+Working directory updated to /Users/tusharmathur/Downloads/
 
-    mtd --wd
-    Working directory: /Users/tusharmathur/Downloads/
+mtd --wd
+Working directory: /Users/tusharmathur/Downloads/
 
-    mtd --url="http://path/to/file_one.zip" --file="file_one.zip"
-    mtd --url="http://path/to/file_two.zip" --file="file_two.zip"
-    
-    Both file_one.zip and file_two.zip will be downloaded at the same location /Users/tusharmathur/Downloads/ because that is the default download path.
+mtd --url="http://path/to/file_one.zip" --file="file_one.zip"
+mtd --url="http://path/to/file_two.zip" --file="file_two.zip"
 
-    --clear-wd : Clears the saved working directory.
+Both file_one.zip and file_two.zip will be downloaded at  
+/Users/tusharmathur/Downloads/ 
 
-    --timeout : Sometimes the connections are established but are not transferring any data. Using this setting you can set the maximum amount of time in seconds that it should wait before quitting.
+--clear-wd : Clears the saved working directory.
 
-    --auto-name : Generates the file name on its own by parsing the last element of the url. You will not be required to set the --file parameter while starting a new download. It will also automatically prepend the generated file name with the working directory specified by the --set-wd option.
+--timeout=SECONDS   Set timeout to SECONDS; this is the time that the program should wait before quitting in case no data is transfered.
 
-    --headers : You can specify headers by seperating them using semicolons as follows:
+--auto-name : Automatically generate a file name from the last element of the url. The --set-wd option will still be honored.
 
-    mtd --url="http://path/to/file_one.zip" --file="file_one.zip" --headers="user-agent:crawl-bot;cookie:abc%3D100%3Bpqr%3D200"
-    
-    NOTE: make sure to encode the header values parameters while sending else they might get escaped while parsing.
+--headers=HEADERS   Pass custom HEADERS separated by semicolons, e.g:
+
+mtd --url="http://path/to/file_one.zip" --file="file_one.zip" --headers="user-agent:crawl-bot;cookie:abc%3D100%3Bpqr%3D200"
+
+header values parameters should be encoded or they might get escaped when parsed.


### PR DESCRIPTION
I've tried to keep things as simple as possible, yet I had introduce a new dependency on the `wordwrap` module. The help text is just a simplified version of your `readme`.
